### PR TITLE
Fix "isMSIE" not working in IE11

### DIFF
--- a/imgmap.js
+++ b/imgmap.js
@@ -220,7 +220,7 @@ function imgmap(config) {
 	
 	//browser sniff
 	var ua = navigator.userAgent;
-	this.isMSIE    = (navigator.appName == "Microsoft Internet Explorer");
+	this.isMSIE    = (navigator.appName == "Microsoft Internet Explorer") || (navigator.appName == 'Netscape' && navigator.userAgent.search('Trident') != -1);
 	this.isMSIE5   = this.isMSIE && (ua.indexOf('MSIE 5')   != -1);
 	this.isMSIE5_0 = this.isMSIE && (ua.indexOf('MSIE 5.0') != -1);
 	this.isMSIE7   = this.isMSIE && (ua.indexOf('MSIE 7')   != -1);


### PR DESCRIPTION
[navigator.appName] doesn't work in IE11
It causes incorrect point in mousemove event.

- < IE11 : navigator.appName ==> "Microsoft Internet Explorer"
- IE11 : navigator.appName ==> "Netscape"

```
this.isMSIE    = (navigator.appName == "Microsoft Internet Explorer") || (navigator.appName == 'Netscape' && navigator.userAgent.search('Trident') != -1);
```

"Trident" (also known as MSHTML) is a proprietary layout engine for the Microsoft Windows version of Internet Explorer, developed by Microsoft.
(It was first introduced with the release of Internet Explorer version 4.0) - [Wikipedia](https://en.wikipedia.org/wiki/Trident_(layout_engine))