### PR TITLE
Add Spip imagemap for export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog #
 
+Version 2.3 PR
+  * Added export compatible with the format of the spip plugin [Image cliquable](https://contrib.spip.net/Plugin-Image-Cliquable)
+  * Added a button to change maphilight visibility and list visibility
+
 Version 2.2
   * Updated excanvas to [r3](https://code.google.com/p/imgmap/source/detail?r=3) - should solve IE8 problems
   * Added Example with ExtJs integration, thanks to Colin Bell

--- a/changelog
+++ b/changelog
@@ -2,6 +2,10 @@
 
 = Changelog =
 
+Version 2.3 PR
+ * Added export compatible with the format of the spip plugin Image cliquable
+ * Added a button to change maphilight visibility and list visibility
+
 Version 2.2
  * Updated excanvas to r3 - should solve IE8 problems
  * Added Example with ExtJs integration, thanks to Colin Bell

--- a/examples/example1.html
+++ b/examples/example1.html
@@ -57,7 +57,7 @@
 				<a onclick="toggleFieldset(this.parentNode.parentNode)">Image map areas</a>
 			</legend>
 			<div style="border-bottom: solid 1px #efefef">
-				<div id="button_container">
+				<div id="button_container" style="display: flex; gap: .5rem;">
 					<!-- buttons come here -->
 					<img src="example1_files/add.gif" onclick="myimgmap.addNewArea()" alt="Add new area"
 						title="Add new area" />
@@ -80,7 +80,24 @@
 						<option value='imagemap'>Standard imagemap</option>
 						<option value='css'>CSS imagemap</option>
 						<option value='wiki'>Wiki imagemap</option>
+						<option value="spip">SPIP imagemap</option>
 					</select>
+					<div id="spip_options"
+						style="display: none; display: flex; gap: .2rem;justify-content: center; align-items: center;">
+						<label style="display: none;" for="spip_doc_id">ID of the image: </label>
+						<input style="display: none;" type="text" id="spip_doc_id" size="5">
+						<br>
+						<div style="display: flex; justify-content: center; align-items: center; gap: .5rem;">
+							<div style="display: flex; justify-content: center; align-items: center; gap: .5rem;">
+								<label for="spip_use_maphilight">Enable maphilight</label>
+								<input type="checkbox" id="spip_use_maphilight" checked="checked">
+							</div>
+							<div style="display: flex; justify-content: center; align-items: center; gap: .5rem;">
+								<label for="spip_use_nolist">Enable the links list</label>
+								<input type="checkbox" id="spip_use_nolist" checked="checked">
+							</div>
+						</div>
+					</div>
 					<div>
 						<a class="toggler toggler_off" onclick="gui_toggleMore();return false;">More actions</a>
 						<div id="more_actions" style="display: none; position: absolute;">

--- a/examples/example1.html
+++ b/examples/example1.html
@@ -1,22 +1,25 @@
 <html>
+
 <head>
-<title>Online Image Map Editor - Example 1</title>
-<link rel="stylesheet" href="example1_files/imgmap.css" type="text/css">
-<link rel="stylesheet" href="example1_files/js/colorPicker.css" type="text/css" />
-<!--[if gte IE 6]>
+	<title>Online Image Map Editor - Example 1</title>
+	<link rel="stylesheet" href="example1_files/imgmap.css" type="text/css">
+	<link rel="stylesheet" href="example1_files/js/colorPicker.css" type="text/css" />
+	<!--[if gte IE 6]>
 <script language="javascript" type="text/javascript" src="../excanvas.js"></script>
 <![endif]-->
-<script language="javascript" type="text/javascript" src="example1_files/js/jquery-1.3.2.js"></script>
-<script language="javascript" type="text/javascript" src="example1_files/js/jquery.colorPicker.js"></script>
+	<script language="javascript" type="text/javascript" src="example1_files/js/jquery-1.3.2.js"></script>
+	<script language="javascript" type="text/javascript" src="example1_files/js/jquery.colorPicker.js"></script>
 </head>
-<body>
-<p style="font-size: 12px; font-weight: bold">
-Example 1 shows how to use the imgmap component in a complete imagemap editor application. This example is 
-functionally equivalent to the online editor found at
-<a href="http://www.maschek.hu/imagemap/imgmap">http://www.maschek.hu/imagemap/imgmap</a>.<br/>
-To use the uploader component ("An image on your computer") you will need to open the example from a php-enabled webserver.
 
-</p>
+<body>
+	<p style="font-size: 12px; font-weight: bold">
+		Example 1 shows how to use the imgmap component in a complete imagemap editor application. This example is
+		functionally equivalent to the online editor found at
+		<a href="http://www.maschek.hu/imagemap/imgmap">http://www.maschek.hu/imagemap/imgmap</a>.<br />
+		To use the uploader component ("An image on your computer") you will need to open the example from a php-enabled
+		webserver.
+
+	</p>
 	<form id="img_area_form">
 		<fieldset>
 			<legend>
@@ -25,31 +28,28 @@ To use the uploader component ("An image on your computer") you will need to ope
 			<div>
 				<div class="source_desc">An image on your computer:</div>
 				<div class="source_url">
-					<iframe id="iframe_uploader"
-						name="uploader"
-						src="example1_files/upload.php"
-						scrolling="no"
-						noresize="noresize"
-						frameborder="no"
-						width="240"
-						height="24"></iframe>
+					<iframe id="iframe_uploader" name="uploader" src="example1_files/upload.php" scrolling="no"
+						noresize="noresize" frameborder="no" width="240" height="24"></iframe>
 				</div>
-				<a href="javascript:gui_loadImage(window.frames['uploader'].document.getElementById('src').getAttribute('rel'))" class="source_accept">accept</a><br/>
-				
+				<a href="javascript:gui_loadImage(window.frames['uploader'].document.getElementById('src').getAttribute('rel'))"
+					class="source_accept">accept</a><br />
+
 				<div class="source_desc">An image on the Internet:</div>
 				<div class="source_url"><input type="txt" id="source_url2" value="http://"></div>
-				<a href="javascript:gui_loadImage(document.getElementById('source_url2').value)" class="source_accept">accept</a><br/>
-				
+				<a href="javascript:gui_loadImage(document.getElementById('source_url2').value)"
+					class="source_accept">accept</a><br />
+
 				<div class="source_desc">Use a sample image:</div>
 				<div class="source_url">
 					<select id="source_url3">
-						<option value="example_files/sample1.jpg" >sample 1</option>
-						<option value="example_files/sample2.jpg" >sample 2</option>
-						<option value="example_files/sample3.jpg" >sample 3</option>
-						<option value="example_files/sample4.jpg" >sample 4</option>
+						<option value="example_files/sample1.jpg">sample 1</option>
+						<option value="example_files/sample2.jpg">sample 2</option>
+						<option value="example_files/sample3.jpg">sample 3</option>
+						<option value="example_files/sample4.jpg">sample 4</option>
 					</select>
 				</div>
-				<a href="javascript:gui_loadImage(document.getElementById('source_url3').value);" class="source_accept">accept</a><br/>
+				<a href="javascript:gui_loadImage(document.getElementById('source_url3').value);"
+					class="source_accept">accept</a><br />
 			</div>
 		</fieldset>
 		<fieldset>
@@ -57,54 +57,61 @@ To use the uploader component ("An image on your computer") you will need to ope
 				<a onclick="toggleFieldset(this.parentNode.parentNode)">Image map areas</a>
 			</legend>
 			<div style="border-bottom: solid 1px #efefef">
-			<div id="button_container">
-				<!-- buttons come here -->
-				<img src="example1_files/add.gif" onclick="myimgmap.addNewArea()" alt="Add new area" title="Add new area"/>
-				<img src="example1_files/delete.gif" onclick="myimgmap.removeArea(myimgmap.currentid)" alt="Delete selected area" title="Delete selected area"/>
-				<img src="example1_files/zoom.gif" id="i_preview" onclick="myimgmap.togglePreview();" alt="Preview image map" title="Preview image map"/>
-				<img src="example1_files/html.gif" onclick="gui_htmlShow()" alt="Get image map HTML" title="Get image map HTML"/>
-				<label for="dd_zoom">Zoom:</label>
-				<select onchange="gui_zoom(this)" id="dd_zoom">
-				<option value='0.25'>25%</option>
-				<option value='0.5'>50%</option>
-				<option value='1' selected="1">100%</option>
-				<option value='2'>200%</option>
-				<option value='3'>300%</option>
-				</select>
-				<label for="dd_output">Output:</label> 
-				<select id="dd_output" onchange="return gui_outputChanged(this)">
-				<option value='imagemap'>Standard imagemap</option>
-				<option value='css'>CSS imagemap</option>
-				<option value='wiki'>Wiki imagemap</option>
-				</select>
-				<div>
-					<a class="toggler toggler_off" onclick="gui_toggleMore();return false;">More actions</a>
-					<div id="more_actions" style="display: none; position: absolute;">
-						<div><a href="" onclick="toggleBoundingBox(this); return false;">&nbsp; bounding box</a></div>
-						<div><a href="" onclick="return false">&nbsp; background color </a><input onchange="gui_colorChanged(this)" id="color1" style="display: none;" value="#ffffff"></div>
+				<div id="button_container">
+					<!-- buttons come here -->
+					<img src="example1_files/add.gif" onclick="myimgmap.addNewArea()" alt="Add new area"
+						title="Add new area" />
+					<img src="example1_files/delete.gif" onclick="myimgmap.removeArea(myimgmap.currentid)"
+						alt="Delete selected area" title="Delete selected area" />
+					<img src="example1_files/zoom.gif" id="i_preview" onclick="myimgmap.togglePreview();"
+						alt="Preview image map" title="Preview image map" />
+					<img src="example1_files/html.gif" onclick="gui_htmlShow()" alt="Get image map HTML"
+						title="Get image map HTML" />
+					<label for="dd_zoom">Zoom:</label>
+					<select onchange="gui_zoom(this)" id="dd_zoom">
+						<option value='0.25'>25%</option>
+						<option value='0.5'>50%</option>
+						<option value='1' selected="1">100%</option>
+						<option value='2'>200%</option>
+						<option value='3'>300%</option>
+					</select>
+					<label for="dd_output">Output:</label>
+					<select id="dd_output" onchange="return gui_outputChanged(this)">
+						<option value='imagemap'>Standard imagemap</option>
+						<option value='css'>CSS imagemap</option>
+						<option value='wiki'>Wiki imagemap</option>
+					</select>
+					<div>
+						<a class="toggler toggler_off" onclick="gui_toggleMore();return false;">More actions</a>
+						<div id="more_actions" style="display: none; position: absolute;">
+							<div><a href="" onclick="toggleBoundingBox(this); return false;">&nbsp; bounding box</a>
+							</div>
+							<div><a href="" onclick="return false">&nbsp; background color </a><input
+									onchange="gui_colorChanged(this)" id="color1" style="display: none;"
+									value="#ffffff"></div>
+						</div>
 					</div>
 				</div>
-			</div>
-			<div style="float: right; margin: 0 5px">
-				<select onchange="changelabeling(this)">
-				<option value=''>No labeling</option>
-				<option value='%n' selected='1'>Label with numbers</option>
-				<option value='%a'>Label with alt text</option>
-				<option value='%h'>Label with href</option>
-				<option value='%c'>Label with coords</option>
-				</select>
-			</div>
+				<div style="float: right; margin: 0 5px">
+					<select onchange="changelabeling(this)">
+						<option value=''>No labeling</option>
+						<option value='%n' selected='1'>Label with numbers</option>
+						<option value='%a'>Label with alt text</option>
+						<option value='%h'>Label with href</option>
+						<option value='%c'>Label with coords</option>
+					</select>
+				</div>
 			</div>
 			<div id="form_container" style="clear: both;">
-			<!-- form elements come here -->
-         	</div>
+				<!-- form elements come here -->
+			</div>
 		</fieldset>
 		<fieldset>
 			<legend>
 				<a onclick="toggleFieldset(this.parentNode.parentNode)">Image</a>
 			</legend>
 			<div id="pic_container">
-			</div>			
+			</div>
 		</fieldset>
 		<fieldset>
 			<legend>
@@ -117,13 +124,15 @@ To use the uploader component ("An image on your computer") you will need to ope
 				<a onclick="toggleFieldset(this.parentNode.parentNode)">Code</a>
 			</legend>
 			<div>
-			<div id="output_help">
+				<div id="output_help">
+				</div>
+				<textarea id="html_container"></textarea>
 			</div>
-			<textarea id="html_container"></textarea></div>
 		</fieldset>
 	</form>
 
-<script type="text/javascript" src="../imgmap.js"></script>
-<script type="text/javascript" src="example1_files/default_interface.js"></script>
+	<script type="text/javascript" src="../imgmap.js"></script>
+	<script type="text/javascript" src="example1_files/default_interface.js"></script>
 </body>
+
 </html>

--- a/examples/example1_files/default_interface.js
+++ b/examples/example1_files/default_interface.js
@@ -8,63 +8,77 @@ var myimgmap, props, outputmode, imgroot;
 /** FUNCTION SECTION **********************************************************/
 
 function gui_toggleMore() {
-	var parent = $('#more_actions').parent().find('.toggler');
-	$('#more_actions').css({
-      top: $(parent).offset().top + ($(parent).outerHeight()),
-      left: $(parent).offset().left
-    });	
-	
-	$('#more_actions').slideToggle(200, function () {
-		if ($(this).css('display') == 'none') {
-			$(parent).addClass('toggler_off');
-		}
-		else {
-			$(parent).removeClass('toggler_off');
-		}
-	});
+  var parent = $("#more_actions").parent().find(".toggler");
+  $("#more_actions").css({
+    top: $(parent).offset().top + $(parent).outerHeight(),
+    left: $(parent).offset().left,
+  });
+
+  $("#more_actions").slideToggle(200, function () {
+    if ($(this).css("display") == "none") {
+      $(parent).addClass("toggler_off");
+    } else {
+      $(parent).removeClass("toggler_off");
+    }
+  });
 }
 
 function gui_colorChanged(obj) {
-	myimgmap.pic_container.style.backgroundColor = obj.value;
-	gui_toggleMore();
+  myimgmap.pic_container.style.backgroundColor = obj.value;
+  gui_toggleMore();
 }
-
 
 /**
  *	Handles mouseover on props row.
  */
 function gui_row_mouseover(e) {
-	if (myimgmap.is_drawing) {return;}//exit if in drawing state
-	if (myimgmap.viewmode === 1) {return;}//exit if preview mode
-	var obj = (myimgmap.isMSIE) ? window.event.srcElement : e.currentTarget;
-	if (typeof obj.aid == 'undefined') {obj = obj.parentNode;}
-	//console.log(obj.aid);
-	myimgmap.highlightArea(obj.aid);
+  if (myimgmap.is_drawing) {
+    return;
+  } //exit if in drawing state
+  if (myimgmap.viewmode === 1) {
+    return;
+  } //exit if preview mode
+  var obj = myimgmap.isMSIE ? window.event.srcElement : e.currentTarget;
+  if (typeof obj.aid == "undefined") {
+    obj = obj.parentNode;
+  }
+  //console.log(obj.aid);
+  myimgmap.highlightArea(obj.aid);
 }
 
 /**
  *	Handles mouseout on props row.
  */
 function gui_row_mouseout(e) {
-	if (myimgmap.is_drawing) {return;}//exit if in drawing state
-	if (myimgmap.viewmode === 1) {return;}//exit if preview mode
-	var obj = (myimgmap.isMSIE) ? window.event.srcElement : e.currentTarget;
-	if (typeof obj.aid == 'undefined') {obj = obj.parentNode;}
-	myimgmap.blurArea(obj.aid);
+  if (myimgmap.is_drawing) {
+    return;
+  } //exit if in drawing state
+  if (myimgmap.viewmode === 1) {
+    return;
+  } //exit if preview mode
+  var obj = myimgmap.isMSIE ? window.event.srcElement : e.currentTarget;
+  if (typeof obj.aid == "undefined") {
+    obj = obj.parentNode;
+  }
+  myimgmap.blurArea(obj.aid);
 }
 
 /**
  *	Handles click on props row.
  */
 function gui_row_click(e) {
-	if (myimgmap.viewmode === 1) {return;}//exit if preview mode
-	var obj = (myimgmap.isMSIE) ? window.event.srcElement : e.currentTarget;
-	//var multiple = (e.originalTarget.name == 'img_active');
-	//myimgmap.log(e.originalTarget);
-	if (typeof obj.aid == 'undefined') {obj = obj.parentNode;}
-	//gui_row_select(obj.aid, false, multiple);
-	gui_row_select(obj.aid, false, false);
-	myimgmap.currentid = obj.aid;
+  if (myimgmap.viewmode === 1) {
+    return;
+  } //exit if preview mode
+  var obj = myimgmap.isMSIE ? window.event.srcElement : e.currentTarget;
+  //var multiple = (e.originalTarget.name == 'img_active');
+  //myimgmap.log(e.originalTarget);
+  if (typeof obj.aid == "undefined") {
+    obj = obj.parentNode;
+  }
+  //gui_row_select(obj.aid, false, multiple);
+  gui_row_select(obj.aid, false, false);
+  myimgmap.currentid = obj.aid;
 }
 
 /**
@@ -73,48 +87,56 @@ function gui_row_click(e) {
  *	@date	2006-06-06 16:55:29
  */
 function gui_row_select(id, setfocus, multiple) {
-	if (myimgmap.is_drawing) {return;}//exit if in drawing state
-	if (myimgmap.viewmode === 1) {return;}//exit if preview mode
-	if (!document.getElementById('img_active_'+id)) {return;}
-	//if (!multiple) 
-	gui_cb_unselect_all();
-	document.getElementById('img_active_'+id).checked = 1;
-	if (setfocus) {
-		document.getElementById('img_active_'+id).focus();
-	}
-	//remove all background styles
-	for (var i = 0; i < props.length; i++) {
-		if (props[i]) {
-			props[i].style.background = '';
-		}
-	}
-	//put highlight on actual props row
-	props[id].style.background = '#e7e7e7';
+  if (myimgmap.is_drawing) {
+    return;
+  } //exit if in drawing state
+  if (myimgmap.viewmode === 1) {
+    return;
+  } //exit if preview mode
+  if (!document.getElementById("img_active_" + id)) {
+    return;
+  }
+  //if (!multiple)
+  gui_cb_unselect_all();
+  document.getElementById("img_active_" + id).checked = 1;
+  if (setfocus) {
+    document.getElementById("img_active_" + id).focus();
+  }
+  //remove all background styles
+  for (var i = 0; i < props.length; i++) {
+    if (props[i]) {
+      props[i].style.background = "";
+    }
+  }
+  //put highlight on actual props row
+  props[id].style.background = "#e7e7e7";
 }
 
 /**
  *	Handles delete keypress when focus is on the leading checkbox/radio.
- *	@author	adam 
+ *	@author	adam
  */
 function gui_cb_keydown(e) {
-	if (myimgmap.viewmode === 1) {return;}//exit if preview mode
-	var key = (myimgmap.isMSIE) ? event.keyCode : e.keyCode;
-	//alert(key);
-	if (key == 46) {
-		//delete pressed
-		myimgmap.removeArea(myimgmap.currentid);
-	}
+  if (myimgmap.viewmode === 1) {
+    return;
+  } //exit if preview mode
+  var key = myimgmap.isMSIE ? event.keyCode : e.keyCode;
+  //alert(key);
+  if (key == 46) {
+    //delete pressed
+    myimgmap.removeArea(myimgmap.currentid);
+  }
 }
 
 /**
  *	Unchecks all checboxes/radios.
  */
 function gui_cb_unselect_all() {
-	for (var i = 0; i < props.length; i++) {
-		if (props[i]) {
-			document.getElementById('img_active_'+i).checked = false;
-		}
-	}
+  for (var i = 0; i < props.length; i++) {
+    if (props[i]) {
+      document.getElementById("img_active_" + i).checked = false;
+    }
+  }
 }
 
 /**
@@ -124,37 +146,46 @@ function gui_cb_unselect_all() {
  *	@date	25-09-2007 17:12:43
  */
 function gui_coords_keydown(e) {
-	if (myimgmap.viewmode === 1) {return;}//exit if preview mode
-	var key = (myimgmap.isMSIE || myimgmap.isOpera) ? event.keyCode : e.keyCode;
-	var obj = (myimgmap.isMSIE || myimgmap.isOpera) ? window.event.srcElement : e.originalTarget;
-	//obj is the input field
-	//this.log(key);
-	//this.log(obj);
-	if (key == 40 || key == 38) {
-		//down or up pressed
-		//get the coords
-		var coords = obj.value.split(',');
-		var s = getSelectionStart(obj);//helper function
-		var j = 0;
-		for (var i=0, le = coords.length; i<le; i++) {
-			j+=coords[i].length;
-			if (j > s) {
-				//this is the coord we want
-				if (key == 40 && coords[i] > 0) {coords[i]--;}
-				if (key == 38) {coords[i]++;}
-				break;
-			}
-			//jump one more because of comma
-			j++;
-		}
-		obj.value = coords.join(',');
-		if (obj.value != myimgmap.areas[obj.parentNode.aid].lastInput) {
-			myimgmap._recalculate(obj.parentNode.aid, obj.value);//contains repaint
-		}
-		//set cursor back to its original position
-		setSelectionRange(obj, s);
-		return true;
-	}
+  if (myimgmap.viewmode === 1) {
+    return;
+  } //exit if preview mode
+  var key = myimgmap.isMSIE || myimgmap.isOpera ? event.keyCode : e.keyCode;
+  var obj =
+    myimgmap.isMSIE || myimgmap.isOpera
+      ? window.event.srcElement
+      : e.originalTarget;
+  //obj is the input field
+  //this.log(key);
+  //this.log(obj);
+  if (key == 40 || key == 38) {
+    //down or up pressed
+    //get the coords
+    var coords = obj.value.split(",");
+    var s = getSelectionStart(obj); //helper function
+    var j = 0;
+    for (var i = 0, le = coords.length; i < le; i++) {
+      j += coords[i].length;
+      if (j > s) {
+        //this is the coord we want
+        if (key == 40 && coords[i] > 0) {
+          coords[i]--;
+        }
+        if (key == 38) {
+          coords[i]++;
+        }
+        break;
+      }
+      //jump one more because of comma
+      j++;
+    }
+    obj.value = coords.join(",");
+    if (obj.value != myimgmap.areas[obj.parentNode.aid].lastInput) {
+      myimgmap._recalculate(obj.parentNode.aid, obj.value); //contains repaint
+    }
+    //set cursor back to its original position
+    setSelectionRange(obj, s);
+    return true;
+  }
 }
 
 /**
@@ -163,15 +194,16 @@ function gui_coords_keydown(e) {
  *	@url	http://javascript.nwbox.com/cursor_position/
  */
 function getSelectionStart(obj) {
-	if (obj.createTextRange) {
-		var r = document.selection.createRange().duplicate();
-		r.moveEnd('character', obj.value.length);
-		if (r.text === '') {return obj.value.length;}
-		return obj.value.lastIndexOf(r.text);
-	}
-	else {
-		return obj.selectionStart;
-	}
+  if (obj.createTextRange) {
+    var r = document.selection.createRange().duplicate();
+    r.moveEnd("character", obj.value.length);
+    if (r.text === "") {
+      return obj.value.length;
+    }
+    return obj.value.lastIndexOf(r.text);
+  } else {
+    return obj.selectionStart;
+  }
 }
 
 /**
@@ -179,20 +211,20 @@ function getSelectionStart(obj) {
  *	@link	http://www.codingforums.com/archive/index.php/t-90176.html
  */
 function setSelectionRange(obj, start, end) {
-	if (typeof end == "undefined") {end = start;}
-	if (obj.setSelectionRange) {
-		obj.focus(); // to make behaviour consistent with IE
-		obj.setSelectionRange(start, end);
-	}
-	else if (obj.createTextRange) {
-		var range = obj.createTextRange();
-		range.collapse(true);
-		range.moveEnd('character', end);
-		range.moveStart('character', start);
-		range.select();
-	}
+  if (typeof end == "undefined") {
+    end = start;
+  }
+  if (obj.setSelectionRange) {
+    obj.focus(); // to make behaviour consistent with IE
+    obj.setSelectionRange(start, end);
+  } else if (obj.createTextRange) {
+    var range = obj.createTextRange();
+    range.collapse(true);
+    range.moveEnd("character", end);
+    range.moveStart("character", start);
+    range.select();
+  }
 }
-
 
 /**
  *	Called when one of the properties change, and the recalculate function
@@ -201,205 +233,278 @@ function setSelectionRange(obj, start, end) {
  *	@author	Adam Maschek (adam.maschek(at)gmail.com)
  */
 function gui_input_change(e) {
-	if (myimgmap.viewmode === 1) {return;}//exit if preview mode
-	if (myimgmap.is_drawing) {return;}//exit if drawing
-	//console.log('blur');
-	var obj = (myimgmap.isMSIE) ? window.event.srcElement : e.currentTarget;
-	//console.log(obj);
-	var id = obj.parentNode.aid;
-	//console.log(this.areas[id]);
-	if (obj.name == 'img_href')        {myimgmap.areas[id].ahref   = obj.value;}
-	else if (obj.name == 'img_alt')    {myimgmap.areas[id].aalt    = obj.value;}
-	else if (obj.name == 'img_title')  {myimgmap.areas[id].atitle  = obj.value;}
-	else if (obj.name == 'img_target') {myimgmap.areas[id].atarget = obj.value;}
-	else if (obj.name == 'img_shape') {
-		if (myimgmap.areas[id].shape != obj.value && myimgmap.areas[id].shape != 'undefined') {
-			//shape changed, adjust coords intelligently inside _normCoords
-			var coords = '';
-			if (props[id]) {
-				coords  =  props[id].getElementsByTagName('input')[2].value;
-			}
-			else {
-				coords = myimgmap.areas[id].lastInput || '' ;
-			}
-			coords = myimgmap._normCoords(coords, obj.value, 'from'+myimgmap.areas[id].shape);
-			if (props[id]) {
-				props[id].getElementsByTagName('input')[2].value  = coords;
-			}
-			myimgmap.areas[id].shape = obj.value;
-			myimgmap._recalculate(id, coords);
-			myimgmap.areas[id].lastInput = coords;
-		}
-		else if (myimgmap.areas[id].shape == 'undefined') {
-			myimgmap.nextShape = obj.value;
-		}
-	}
-	if (myimgmap.areas[id] && myimgmap.areas[id].shape != 'undefined') {
-		myimgmap._recalculate(id, props[id].getElementsByTagName('input')[2].value);
-		myimgmap.fireEvent('onHtmlChanged', myimgmap.getMapHTML());//temp ## shouldnt be here
-	}
+  if (myimgmap.viewmode === 1) {
+    return;
+  } //exit if preview mode
+  if (myimgmap.is_drawing) {
+    return;
+  } //exit if drawing
+  //console.log('blur');
+  var obj = myimgmap.isMSIE ? window.event.srcElement : e.currentTarget;
+  //console.log(obj);
+  var id = obj.parentNode.aid;
+  //console.log(this.areas[id]);
+  if (obj.name == "img_href") {
+    myimgmap.areas[id].ahref = obj.value;
+  } else if (obj.name == "img_alt") {
+    myimgmap.areas[id].aalt = obj.value;
+  } else if (obj.name == "img_title") {
+    myimgmap.areas[id].atitle = obj.value;
+  } else if (obj.name == "img_target") {
+    myimgmap.areas[id].atarget = obj.value;
+  } else if (obj.name == "img_shape") {
+    if (
+      myimgmap.areas[id].shape != obj.value &&
+      myimgmap.areas[id].shape != "undefined"
+    ) {
+      //shape changed, adjust coords intelligently inside _normCoords
+      var coords = "";
+      if (props[id]) {
+        coords = props[id].getElementsByTagName("input")[2].value;
+      } else {
+        coords = myimgmap.areas[id].lastInput || "";
+      }
+      coords = myimgmap._normCoords(
+        coords,
+        obj.value,
+        "from" + myimgmap.areas[id].shape
+      );
+      if (props[id]) {
+        props[id].getElementsByTagName("input")[2].value = coords;
+      }
+      myimgmap.areas[id].shape = obj.value;
+      myimgmap._recalculate(id, coords);
+      myimgmap.areas[id].lastInput = coords;
+    } else if (myimgmap.areas[id].shape == "undefined") {
+      myimgmap.nextShape = obj.value;
+    }
+  }
+  if (myimgmap.areas[id] && myimgmap.areas[id].shape != "undefined") {
+    myimgmap._recalculate(id, props[id].getElementsByTagName("input")[2].value);
+    myimgmap.fireEvent("onHtmlChanged", myimgmap.getMapHTML()); //temp ## shouldnt be here
+  }
 }
 
 /**
  *	Called from imgmap when a new area is added.
  */
 function gui_addArea(id) {
-	//var id = props.length;
-	//id = 1;
-	props[id] = document.createElement('DIV');
-	document.getElementById('form_container').appendChild(props[id]);
+  //var id = props.length;
+  //id = 1;
+  props[id] = document.createElement("DIV");
+  document.getElementById("form_container").appendChild(props[id]);
 
-	props[id].id        = 'img_area_' + id;
-	props[id].aid       = id;
-	props[id].className = 'img_area';
-	//hook ROW event handlers
-	myimgmap.addEvent(props[id], 'mouseover', gui_row_mouseover);
-	myimgmap.addEvent(props[id], 'mouseout',  gui_row_mouseout);
-	myimgmap.addEvent(props[id], 'click',     gui_row_click);
-	var temp = '<input type="text"  name="img_id" class="img_id" value="' + id + '" readonly="1"/>';
-	//temp+= '<input type="checkbox" name="img_active" class="img_active" id="img_active_'+id+'" value="'+id+'">';
-	//could be checkbox in the future
-	temp+= '<input type="radio" name="img_active" class="img_active" id="img_active_'+id+'" value="'+id+'">';
-	temp+= '<select name="img_shape" class="img_shape">';
-	temp+= '<option value="rect">rectangle</option>';
-	if (document.getElementById('dd_output').value != 'css') {
-		temp+= '<option value="circle">circle</option>';
-		temp+= '<option value="poly">polygon</option>';
-		temp+= '<option value="bezier1">bezier</option>';
-	}
-	temp+= '</select>';
-	temp+= 'Coords: <input type="text" name="img_coords" class="img_coords" value="">';
-	temp+= 'Href: <input type="text" name="img_href" class="img_href" value="">';
-	temp+= 'Alt: <input type="text" name="img_alt" class="img_alt" value="">';
-	temp+= 'Target: <select name="img_target" class="img_target">';
-	temp+= '<option value=""  >&lt;not set&gt;</option>';
-	temp+= '<option value="_self"  >this window</option>';
-	temp+= '<option value="_blank" >new window</option>';
-	temp+= '<option value="_top"   >top window</option>';
-	temp+= '</select>';
-	props[id].innerHTML = temp;
-	//hook more event handlers to individual inputs
-	
-	myimgmap.addEvent(props[id].getElementsByTagName('input')[1],  'keydown', gui_cb_keydown);
-	myimgmap.addEvent(props[id].getElementsByTagName('input')[2],  'keydown', gui_coords_keydown);
-	myimgmap.addEvent(props[id].getElementsByTagName('input')[2],  'change', gui_input_change);
-	myimgmap.addEvent(props[id].getElementsByTagName('input')[3],  'change', gui_input_change);
-	myimgmap.addEvent(props[id].getElementsByTagName('input')[4],  'change', gui_input_change);
-	myimgmap.addEvent(props[id].getElementsByTagName('select')[0], 'change', gui_input_change);
-	myimgmap.addEvent(props[id].getElementsByTagName('select')[1], 'change', gui_input_change);
-	if (myimgmap.isSafari) {
-		//need these for safari
-		myimgmap.addEvent(props[id].getElementsByTagName('select')[0], 'change', gui_row_click);
-		myimgmap.addEvent(props[id].getElementsByTagName('select')[1], 'change', gui_row_click);
-	}
-	//set shape as nextshape if set
-	if (myimgmap.nextShape) {props[id].getElementsByTagName('select')[0].value = myimgmap.nextShape;}
-	//alert(this.props[id].parentNode.innerHTML);
-	gui_row_select(id, true);
+  props[id].id = "img_area_" + id;
+  props[id].aid = id;
+  props[id].className = "img_area";
+  //hook ROW event handlers
+  myimgmap.addEvent(props[id], "mouseover", gui_row_mouseover);
+  myimgmap.addEvent(props[id], "mouseout", gui_row_mouseout);
+  myimgmap.addEvent(props[id], "click", gui_row_click);
+  var temp =
+    '<input type="text"  name="img_id" class="img_id" value="' +
+    id +
+    '" readonly="1"/>';
+  //temp+= '<input type="checkbox" name="img_active" class="img_active" id="img_active_'+id+'" value="'+id+'">';
+  //could be checkbox in the future
+  temp +=
+    '<input type="radio" name="img_active" class="img_active" id="img_active_' +
+    id +
+    '" value="' +
+    id +
+    '">';
+  temp += '<select name="img_shape" class="img_shape">';
+  temp += '<option value="rect">rectangle</option>';
+  if (document.getElementById("dd_output").value != "css") {
+    temp += '<option value="circle">circle</option>';
+    temp += '<option value="poly">polygon</option>';
+    temp += '<option value="bezier1">bezier</option>';
+  }
+  temp += "</select>";
+  temp +=
+    'Coords: <input type="text" name="img_coords" class="img_coords" value="">';
+  temp += 'Href: <input type="text" name="img_href" class="img_href" value="">';
+  temp += 'Alt: <input type="text" name="img_alt" class="img_alt" value="">';
+  temp += 'Target: <select name="img_target" class="img_target">';
+  temp += '<option value=""  >&lt;not set&gt;</option>';
+  temp += '<option value="_self"  >this window</option>';
+  temp += '<option value="_blank" >new window</option>';
+  temp += '<option value="_top"   >top window</option>';
+  temp += "</select>";
+  props[id].innerHTML = temp;
+  //hook more event handlers to individual inputs
+
+  myimgmap.addEvent(
+    props[id].getElementsByTagName("input")[1],
+    "keydown",
+    gui_cb_keydown
+  );
+  myimgmap.addEvent(
+    props[id].getElementsByTagName("input")[2],
+    "keydown",
+    gui_coords_keydown
+  );
+  myimgmap.addEvent(
+    props[id].getElementsByTagName("input")[2],
+    "change",
+    gui_input_change
+  );
+  myimgmap.addEvent(
+    props[id].getElementsByTagName("input")[3],
+    "change",
+    gui_input_change
+  );
+  myimgmap.addEvent(
+    props[id].getElementsByTagName("input")[4],
+    "change",
+    gui_input_change
+  );
+  myimgmap.addEvent(
+    props[id].getElementsByTagName("select")[0],
+    "change",
+    gui_input_change
+  );
+  myimgmap.addEvent(
+    props[id].getElementsByTagName("select")[1],
+    "change",
+    gui_input_change
+  );
+  if (myimgmap.isSafari) {
+    //need these for safari
+    myimgmap.addEvent(
+      props[id].getElementsByTagName("select")[0],
+      "change",
+      gui_row_click
+    );
+    myimgmap.addEvent(
+      props[id].getElementsByTagName("select")[1],
+      "change",
+      gui_row_click
+    );
+  }
+  //set shape as nextshape if set
+  if (myimgmap.nextShape) {
+    props[id].getElementsByTagName("select")[0].value = myimgmap.nextShape;
+  }
+  //alert(this.props[id].parentNode.innerHTML);
+  gui_row_select(id, true);
 }
 
 /**
  *	Called from imgmap when an area was removed.
  */
 function gui_removeArea(id) {
-	if (props[id]) {
-		//shall we leave the last one?
-		var pprops = props[id].parentNode;
-		pprops.removeChild(props[id]);
-		var lastid = pprops.lastChild.aid;
-		props[id] = null;
-		try {
-			gui_row_select(lastid, true);
-			myimgmap.currentid = lastid;
-		}
-		catch (err) {
-			//alert('noparent');
-		}
-	}
+  if (props[id]) {
+    //shall we leave the last one?
+    var pprops = props[id].parentNode;
+    pprops.removeChild(props[id]);
+    var lastid = pprops.lastChild.aid;
+    props[id] = null;
+    try {
+      gui_row_select(lastid, true);
+      myimgmap.currentid = lastid;
+    } catch (err) {
+      //alert('noparent');
+    }
+  }
 }
 
 /**
  *	Called from imgmap when mode changed to a given value (preview or normal)
  */
 function gui_modeChanged(mode) {
-	var nodes, i;
-	if (mode == 1) {
-		//preview mode
-		if (document.getElementById('html_container')) {
-			document.getElementById('html_container').disabled = true;
-		}
-		//disable form elements (inputs and selects)
-		nodes = document.getElementById('form_container').getElementsByTagName("input");
-		for (i=0; i<nodes.length; i++) {
-			nodes[i].disabled = true;
-		}
-		nodes = document.getElementById('form_container').getElementsByTagName("select");
-		for (i=0; i<nodes.length; i++) {
-			nodes[i].disabled = true;
-		}
-		document.getElementById('i_preview').src = imgroot + 'edit.gif';
-		document.getElementById('dd_zoom').disabled = true;
-		document.getElementById('dd_output').disabled = true;
-	}
-	else {
-		//normal mode
-		if (document.getElementById('html_container')) {
-			document.getElementById('html_container').disabled = false;
-		}
-		//enable form elements (inputs and selects)
-		nodes = document.getElementById('form_container').getElementsByTagName("input");
-		for (i=0; i<nodes.length; i++) {
-			nodes[i].disabled = false;
-		}
-		nodes = document.getElementById('form_container').getElementsByTagName("select");
-		for (i=0; i<nodes.length; i++) {
-			nodes[i].disabled = false;
-		}
-		document.getElementById('i_preview').src = imgroot + 'zoom.gif';
-		document.getElementById('dd_zoom').disabled = false;
-		document.getElementById('dd_output').disabled = false;
-	}
+  var nodes, i;
+  if (mode == 1) {
+    //preview mode
+    if (document.getElementById("html_container")) {
+      document.getElementById("html_container").disabled = true;
+    }
+    //disable form elements (inputs and selects)
+    nodes = document
+      .getElementById("form_container")
+      .getElementsByTagName("input");
+    for (i = 0; i < nodes.length; i++) {
+      nodes[i].disabled = true;
+    }
+    nodes = document
+      .getElementById("form_container")
+      .getElementsByTagName("select");
+    for (i = 0; i < nodes.length; i++) {
+      nodes[i].disabled = true;
+    }
+    document.getElementById("i_preview").src = imgroot + "edit.gif";
+    document.getElementById("dd_zoom").disabled = true;
+    document.getElementById("dd_output").disabled = true;
+  } else {
+    //normal mode
+    if (document.getElementById("html_container")) {
+      document.getElementById("html_container").disabled = false;
+    }
+    //enable form elements (inputs and selects)
+    nodes = document
+      .getElementById("form_container")
+      .getElementsByTagName("input");
+    for (i = 0; i < nodes.length; i++) {
+      nodes[i].disabled = false;
+    }
+    nodes = document
+      .getElementById("form_container")
+      .getElementsByTagName("select");
+    for (i = 0; i < nodes.length; i++) {
+      nodes[i].disabled = false;
+    }
+    document.getElementById("i_preview").src = imgroot + "zoom.gif";
+    document.getElementById("dd_zoom").disabled = false;
+    document.getElementById("dd_output").disabled = false;
+  }
 }
 
 /**
  *	Called from imgmap with the new html code when changed.
  */
 function gui_htmlChanged(str) {
-	var out = document.getElementById('dd_output').value;
-	if (document.getElementById('html_container')) {
-		if (out == 'css') {
-			document.getElementById('html_container').value = output_css();
-		}
-		else if (out == 'wiki') {
-			document.getElementById('html_container').value = output_wiki();
-		}
-		else {
-			document.getElementById('html_container').value = str;
-		}
-	}
+  var out = document.getElementById("dd_output").value;
+  if (document.getElementById("html_container")) {
+    if (out == "css") {
+      document.getElementById("html_container").value = output_css();
+    } else if (out == "wiki") {
+      document.getElementById("html_container").value = output_wiki();
+    } else {
+      document.getElementById("html_container").value = str;
+    }
+  }
 }
 
 /**
  *	Called from imgmap with new status string.
  */
 function gui_statusMessage(str) {
-	if (document.getElementById('status_container')) {
-		document.getElementById('status_container').innerHTML = str;
-	}
-	window.defaultStatus = str;//for IE
+  if (document.getElementById("status_container")) {
+    document.getElementById("status_container").innerHTML = str;
+  }
+  window.defaultStatus = str; //for IE
 }
 
 function gui_areaChanged(area) {
-	var id = area.aid;
-	if (props[id]) {
-		if (area.shape)  {props[id].getElementsByTagName('select')[0].value = area.shape;}
-		if (area.lastInput) {props[id].getElementsByTagName('input')[2].value  = area.lastInput;}
-		if (area.ahref)   {props[id].getElementsByTagName('input')[3].value  = area.ahref;}
-		if (area.aalt)    {props[id].getElementsByTagName('input')[4].value  = area.aalt;}
-		if (area.atarget) {props[id].getElementsByTagName('select')[1].value = area.atarget;}
-	}
+  var id = area.aid;
+  if (props[id]) {
+    if (area.shape) {
+      props[id].getElementsByTagName("select")[0].value = area.shape;
+    }
+    if (area.lastInput) {
+      props[id].getElementsByTagName("input")[2].value = area.lastInput;
+    }
+    if (area.ahref) {
+      props[id].getElementsByTagName("input")[3].value = area.ahref;
+    }
+    if (area.aalt) {
+      props[id].getElementsByTagName("input")[4].value = area.aalt;
+    }
+    if (area.atarget) {
+      props[id].getElementsByTagName("select")[1].value = area.atarget;
+    }
+  }
 }
-
 
 /**
  *	Called when the grand HTML code loses focus, and the changes must be reflected.
@@ -407,14 +512,16 @@ function gui_areaChanged(area) {
  *	@author	Adam Maschek (adam.maschek(at)gmail.com)
  */
 function gui_htmlBlur() {
-	var elem = document.getElementById('html_container');
-	var oldvalue = elem.getAttribute('oldvalue');
-	if (oldvalue != elem.value && document.getElementById('dd_output').value == 'imagemap') {
-		//dirty
-		myimgmap.setMapHTML(elem.value);
-	}
+  var elem = document.getElementById("html_container");
+  var oldvalue = elem.getAttribute("oldvalue");
+  if (
+    oldvalue != elem.value &&
+    document.getElementById("dd_output").value == "imagemap"
+  ) {
+    //dirty
+    myimgmap.setMapHTML(elem.value);
+  }
 }
-
 
 /**
  *	Called when the optional html container gets focus.
@@ -424,22 +531,22 @@ function gui_htmlBlur() {
  *	@author Adam Maschek (adam.maschek(at)gmail.com)
  */
 function gui_htmlFocus() {
-	var elem = document.getElementById('html_container');
-	elem.setAttribute('oldvalue', elem.value);
-	elem.select();
+  var elem = document.getElementById("html_container");
+  elem.setAttribute("oldvalue", elem.value);
+  elem.select();
 }
 
 function gui_htmlShow() {
-	toggleFieldset(document.getElementById('fieldset_html'), 1);
-	document.getElementById('html_container').focus();
+  toggleFieldset(document.getElementById("fieldset_html"), 1);
+  document.getElementById("html_container").focus();
 }
 
 /**
  *	Change the labeling mode directly in imgmap config then repaint all areas.
  */
 function changelabeling(obj) {
-	myimgmap.config.label = obj.value;
-	myimgmap._repaintAll();
+  myimgmap.config.label = obj.value;
+  myimgmap._repaintAll();
 }
 
 /**
@@ -447,189 +554,242 @@ function changelabeling(obj) {
  *	(Relax just repaints the borders and opacity.)
  */
 function toggleBoundingBox(obj) {
-	obj.checked = !obj.checked;
-	obj.innerHTML = '&nbsp; bounding box';
-	if (obj.checked) {
-		obj.innerHTML = '&raquo; bounding box';
-	}
-	myimgmap.config.bounding_box = obj.checked;
-	myimgmap.relaxAllAreas();
-	gui_toggleMore();
+  obj.checked = !obj.checked;
+  obj.innerHTML = "&nbsp; bounding box";
+  if (obj.checked) {
+    obj.innerHTML = "&raquo; bounding box";
+  }
+  myimgmap.config.bounding_box = obj.checked;
+  myimgmap.relaxAllAreas();
+  gui_toggleMore();
 }
 
 /**
  *	Toggles fieldset visibility by changing the className.
- *	External css needed with the appropriate classnames. 
+ *	External css needed with the appropriate classnames.
  *	@date	2006.10.24. 22:13:34
  *	@author	Adam Maschek (maschek@freemail.hu)
  */
 function toggleFieldset(fieldset, on) {
-	if (fieldset) {
-		if (fieldset.className == 'fieldset_off' || on == 1) {
-			fieldset.className = '';
-		}
-		else {
-			fieldset.className = 'fieldset_off';
-		}
-	}
+  if (fieldset) {
+    if (fieldset.className == "fieldset_off" || on == 1) {
+      fieldset.className = "";
+    } else {
+      fieldset.className = "fieldset_off";
+    }
+  }
 }
 
 function gui_selectArea(obj) {
-	gui_row_select(obj.aid, true, false);
+  gui_row_select(obj.aid, true, false);
 }
 
 function gui_zoom() {
-	var scale = document.getElementById('dd_zoom').value;
-	var pic = document.getElementById('pic_container').getElementsByTagName('img')[0];
-	if (typeof pic == 'undefined') {return false;}
-	if (typeof pic.oldwidth == 'undefined' || !pic.oldwidth) {
-		pic.oldwidth = pic.width;
-	}
-	if (typeof pic.oldheight == 'undefined' || !pic.oldheight) {
-		pic.oldheight = pic.height;
-	}
-	pic.width  = pic.oldwidth * scale;
-	pic.height = pic.oldheight * scale;
-	myimgmap.scaleAllAreas(scale);
+  var scale = document.getElementById("dd_zoom").value;
+  var pic = document
+    .getElementById("pic_container")
+    .getElementsByTagName("img")[0];
+  if (typeof pic == "undefined") {
+    return false;
+  }
+  if (typeof pic.oldwidth == "undefined" || !pic.oldwidth) {
+    pic.oldwidth = pic.width;
+  }
+  if (typeof pic.oldheight == "undefined" || !pic.oldheight) {
+    pic.oldheight = pic.height;
+  }
+  pic.width = pic.oldwidth * scale;
+  pic.height = pic.oldheight * scale;
+  myimgmap.scaleAllAreas(scale);
 }
 
 function gui_loadImage(src) {
-	//reset zoom dropdown
-	document.getElementById('dd_zoom').value = '1';
-	var pic = document.getElementById('pic_container').getElementsByTagName('img')[0];
-	if (typeof pic != 'undefined') {
-		//delete already existing pic
-		pic.parentNode.removeChild(pic);
-		delete myimgmap.pic;
-	}
-	myimgmap.loadImage(src);
+  //reset zoom dropdown
+  document.getElementById("dd_zoom").value = "1";
+  var pic = document
+    .getElementById("pic_container")
+    .getElementsByTagName("img")[0];
+  if (typeof pic != "undefined") {
+    //delete already existing pic
+    pic.parentNode.removeChild(pic);
+    delete myimgmap.pic;
+  }
+  myimgmap.loadImage(src);
 }
 
 function gui_outputChanged() {
-	var temp, i;
-	var clipboard_enabled = (window.clipboardData || typeof air == 'object');
-	var output = document.getElementById('dd_output').value;
-	if (output == 'css') {
-		//css output selected
-		for (i=0; i<myimgmap.areas.length; i++) {
-			if (myimgmap.areas[i] && myimgmap.areas[i].shape != 'rect' && myimgmap.areas[i].shape != 'undefined') {
-				var others = true;
-				break;
-			}
-		}
-		if (others) {
-			if (!confirm('CSS maps only support rectangles. Are you sure you want to transform all your areas to rectangles?')) {
-				output = outputmode;
-				return false;
-			}
-			else {
-				//transform old areas
-				for (i = 0; i < props.length; i++) {
-					if (props[i] && props[i].getElementsByTagName('select')[0].value != 'rect' && myimgmap.areas[i].shape != 'undefined') {
-						var coords = props[i].getElementsByTagName('input')[2].value;
-						coords = myimgmap._normCoords(coords, 'rect', 'from'+myimgmap.areas[i].shape);
-						myimgmap.areas[i].shape = 'rect';
-						myimgmap._recalculate(i, coords);
-						myimgmap.areas[i].lastInput = coords;
-						//dropdown and new coords will be set when setmaphtml is called,see below
-					}
-				}
-			}
-		}
-		else if (myimgmap.areas.length > 0 && !confirm('CSS maps only support rectangles. Are you sure you want to use this output mode?')) {
-			output = outputmode;
-			return false;
-		}
-		temp = 'This is the generated image map HTML + CSS code. ';
-		temp+= 'Click into the textarea below and press Ctrl+C to copy the code to your clipboard. ';
-		if (clipboard_enabled) {
-			temp+= 'Alternatively you can use the clipboard icon on the right. ';
-			temp+= '<img src="example1_files/clipboard.gif" onclick="gui_toClipBoard()" style="float: right; margin: 4px; cursor: pointer;"/>';
-		}
-		temp+= 'Please note, that you have to use a positioned container to make use of the absolute coordinates ';
-		temp+= '(<a href="http://css-tricks.com/absolute-positioning-inside-relative-positioning/">read more</a>).'; 
-	}
-	else if (output == 'wiki') {
-		temp = 'This is the generated image map Wiki code to use with MediaWiki ImageMap extension. ';
-		temp+= 'Click into the textarea below and press Ctrl+C to copy the code to your clipboard. ';
-		if (clipboard_enabled) {
-			temp+= 'Alternatively you can use the clipboard icon on the right. ';
-			temp+= '<img src="example1_files/clipboard.gif" onclick="gui_toClipBoard()" style="float: right; margin: 4px; cursor: pointer;"/>';
-		}
-		temp+= 'Please note, that you might need to change the Image url ';
-		temp+= '(<a href="http://www.mediawiki.org/wiki/Extension:ImageMap">read more</a>).'; 
-	}
-	else {
-		temp = 'This is the generated image map HTML code. ';
-		temp+= 'Click into the textarea below and press Ctrl+C to copy the code to your clipboard. ';
-		if (clipboard_enabled) {
-			temp+= 'Alternatively you can use the clipboard icon on the right. ';
-			temp+= '<img src="example1_files/clipboard.gif" onclick="gui_toClipBoard()" style="float: right; margin: 4px; cursor: pointer;"/>';
-		}
-		temp+= 'Please note, that you have to attach this code to your image, via the usemap property ';
-		temp+= '(<a href="http://www.htmlhelp.com/reference/html40/special/map.html">read more</a>). '; 
-	}
-	document.getElementById('output_help').innerHTML = temp;
-	//this will reload areas and sets dropdown restrictions
-	myimgmap.setMapHTML(myimgmap.getMapHTML());
-	outputmode = output;
-	return true;
+  var temp, i;
+  var clipboard_enabled = window.clipboardData || typeof air == "object";
+  var output = document.getElementById("dd_output").value;
+  if (output == "css") {
+    //css output selected
+    for (i = 0; i < myimgmap.areas.length; i++) {
+      if (
+        myimgmap.areas[i] &&
+        myimgmap.areas[i].shape != "rect" &&
+        myimgmap.areas[i].shape != "undefined"
+      ) {
+        var others = true;
+        break;
+      }
+    }
+    if (others) {
+      if (
+        !confirm(
+          "CSS maps only support rectangles. Are you sure you want to transform all your areas to rectangles?"
+        )
+      ) {
+        output = outputmode;
+        return false;
+      } else {
+        //transform old areas
+        for (i = 0; i < props.length; i++) {
+          if (
+            props[i] &&
+            props[i].getElementsByTagName("select")[0].value != "rect" &&
+            myimgmap.areas[i].shape != "undefined"
+          ) {
+            var coords = props[i].getElementsByTagName("input")[2].value;
+            coords = myimgmap._normCoords(
+              coords,
+              "rect",
+              "from" + myimgmap.areas[i].shape
+            );
+            myimgmap.areas[i].shape = "rect";
+            myimgmap._recalculate(i, coords);
+            myimgmap.areas[i].lastInput = coords;
+            //dropdown and new coords will be set when setmaphtml is called,see below
+          }
+        }
+      }
+    } else if (
+      myimgmap.areas.length > 0 &&
+      !confirm(
+        "CSS maps only support rectangles. Are you sure you want to use this output mode?"
+      )
+    ) {
+      output = outputmode;
+      return false;
+    }
+    temp = "This is the generated image map HTML + CSS code. ";
+    temp +=
+      "Click into the textarea below and press Ctrl+C to copy the code to your clipboard. ";
+    if (clipboard_enabled) {
+      temp += "Alternatively you can use the clipboard icon on the right. ";
+      temp +=
+        '<img src="example1_files/clipboard.gif" onclick="gui_toClipBoard()" style="float: right; margin: 4px; cursor: pointer;"/>';
+    }
+    temp +=
+      "Please note, that you have to use a positioned container to make use of the absolute coordinates ";
+    temp +=
+      '(<a href="http://css-tricks.com/absolute-positioning-inside-relative-positioning/">read more</a>).';
+  } else if (output == "wiki") {
+    temp =
+      "This is the generated image map Wiki code to use with MediaWiki ImageMap extension. ";
+    temp +=
+      "Click into the textarea below and press Ctrl+C to copy the code to your clipboard. ";
+    if (clipboard_enabled) {
+      temp += "Alternatively you can use the clipboard icon on the right. ";
+      temp +=
+        '<img src="example1_files/clipboard.gif" onclick="gui_toClipBoard()" style="float: right; margin: 4px; cursor: pointer;"/>';
+    }
+    temp += "Please note, that you might need to change the Image url ";
+    temp +=
+      '(<a href="http://www.mediawiki.org/wiki/Extension:ImageMap">read more</a>).';
+  } else {
+    temp = "This is the generated image map HTML code. ";
+    temp +=
+      "Click into the textarea below and press Ctrl+C to copy the code to your clipboard. ";
+    if (clipboard_enabled) {
+      temp += "Alternatively you can use the clipboard icon on the right. ";
+      temp +=
+        '<img src="example1_files/clipboard.gif" onclick="gui_toClipBoard()" style="float: right; margin: 4px; cursor: pointer;"/>';
+    }
+    temp +=
+      "Please note, that you have to attach this code to your image, via the usemap property ";
+    temp +=
+      '(<a href="http://www.htmlhelp.com/reference/html40/special/map.html">read more</a>). ';
+  }
+  document.getElementById("output_help").innerHTML = temp;
+  //this will reload areas and sets dropdown restrictions
+  myimgmap.setMapHTML(myimgmap.getMapHTML());
+  outputmode = output;
+  return true;
 }
-
 
 /**
  *	Tries to copy imagemap output or text parameter to the clipboard.
- *	If in special environment (eg AIR), use specific functions. 
+ *	If in special environment (eg AIR), use specific functions.
  *	@date	2006.10.24. 22:14:12
  *	@param	text	Text to copy, otherwise html_container will be used.
  */
 function gui_toClipBoard(text) {
-	if (typeof text == 'undefined') {text = document.getElementById('html_container').value;}
-	try {
-		if (window.clipboardData) {
-			// IE send-to-clipboard method.
-			window.clipboardData.setData('Text', text);
-		}
-		else if (typeof air == 'object') {
-			air.Clipboard.generalClipboard.clear();
-			air.Clipboard.generalClipboard.setData("air:text", text, false);
-		}
-	}
-	catch (err) {
-		myimgmap.log("Unable to set clipboard data", 1);
-	}
+  if (typeof text == "undefined") {
+    text = document.getElementById("html_container").value;
+  }
+  try {
+    if (window.clipboardData) {
+      // IE send-to-clipboard method.
+      window.clipboardData.setData("Text", text);
+    } else if (typeof air == "object") {
+      air.Clipboard.generalClipboard.clear();
+      air.Clipboard.generalClipboard.setData("air:text", text, false);
+    }
+  } catch (err) {
+    myimgmap.log("Unable to set clipboard data", 1);
+  }
 }
-
 
 /** INIT SECTION **************************************************************/
 
 //instantiate the imgmap component, setting up some basic config values
 myimgmap = new imgmap({
-mode : "editor",
-custom_callbacks : {
-	'onStatusMessage' : function(str) {gui_statusMessage(str);},//to display status messages on gui
-	'onHtmlChanged'   : function(str) {gui_htmlChanged(str);},//to display updated html on gui
-	'onModeChanged'   : function(mode) {gui_modeChanged(mode);},//to switch normal and preview modes on gui
-	'onAddArea'       : function(id)  {gui_addArea(id);},//to add new form element on gui
-	'onRemoveArea'    : function(id)  {gui_removeArea(id);},//to remove form elements from gui
-	'onAreaChanged'   : function(obj) {gui_areaChanged(obj);},
-	'onSelectArea'    : function(obj) {gui_selectArea(obj);}//to select form element when an area is clicked
-},
-pic_container: document.getElementById('pic_container'),
-bounding_box : false
+  mode: "editor",
+  custom_callbacks: {
+    onStatusMessage: function (str) {
+      gui_statusMessage(str);
+    }, //to display status messages on gui
+    onHtmlChanged: function (str) {
+      gui_htmlChanged(str);
+    }, //to display updated html on gui
+    onModeChanged: function (mode) {
+      gui_modeChanged(mode);
+    }, //to switch normal and preview modes on gui
+    onAddArea: function (id) {
+      gui_addArea(id);
+    }, //to add new form element on gui
+    onRemoveArea: function (id) {
+      gui_removeArea(id);
+    }, //to remove form elements from gui
+    onAreaChanged: function (obj) {
+      gui_areaChanged(obj);
+    },
+    onSelectArea: function (obj) {
+      gui_selectArea(obj);
+    }, //to select form element when an area is clicked
+  },
+  pic_container: document.getElementById("pic_container"),
+  bounding_box: false,
 });
 
 //array of form elements
 props = [];
-imgroot = 'example1_files/';
-outputmode = 'imgmap';
+imgroot = "example1_files/";
+outputmode = "imgmap";
 gui_outputChanged();
 
-myimgmap.addEvent(document.getElementById('html_container'), 'blur',  gui_htmlBlur);
-myimgmap.addEvent(document.getElementById('html_container'), 'focus', gui_htmlFocus);
+myimgmap.addEvent(
+  document.getElementById("html_container"),
+  "blur",
+  gui_htmlBlur
+);
+myimgmap.addEvent(
+  document.getElementById("html_container"),
+  "focus",
+  gui_htmlFocus
+);
 
-$('#color1').colorPicker();
-
+$("#color1").colorPicker();
 
 /** OUTPUT FUNCTIONS **********************************************************/
 
@@ -637,30 +797,48 @@ $('#color1').colorPicker();
  *	Just grab the areas array and do whatever you wish.
  */
 function output_css() {
-	var html, coords, top, left, width, height;
-	html = '<div class="imgmap_css_container" id="'+myimgmap.getMapId()+'">';
-	
-	//foreach areas
-	for (var i=0; i<myimgmap.areas.length; i++) {
-		if (myimgmap.areas[i]) {
-			if (myimgmap.areas[i].shape && myimgmap.areas[i].shape != 'undefined') {
-				coords = myimgmap.areas[i].lastInput;
-				top = myimgmap.areas[i].style.top;
-				left = myimgmap.areas[i].style.left;
-				width = myimgmap.areas[i].style.width;
-				height = myimgmap.areas[i].style.height;
-				html+= '<a style="position: absolute; top: '+top+'; left: '+left+'; width: '+width+'; height: '+height+';" '+
-					' alt="' + myimgmap.areas[i].aalt + '"' +
-					' title="' + myimgmap.areas[i].aalt + '"' +
-					' href="' +	myimgmap.areas[i].ahref + '"' +
-					' target="' + myimgmap.areas[i].atarget + '" ><em>' + myimgmap.areas[i].atitle + '</em></a>';
-			}
-		}
-	}
-	html+= myimgmap.waterMark + '</div>';
-	//alert(html);
-	return html;
+  var html, coords, top, left, width, height;
+  html = '<div class="imgmap_css_container" id="' + myimgmap.getMapId() + '">';
 
+  //foreach areas
+  for (var i = 0; i < myimgmap.areas.length; i++) {
+    if (myimgmap.areas[i]) {
+      if (myimgmap.areas[i].shape && myimgmap.areas[i].shape != "undefined") {
+        coords = myimgmap.areas[i].lastInput;
+        top = myimgmap.areas[i].style.top;
+        left = myimgmap.areas[i].style.left;
+        width = myimgmap.areas[i].style.width;
+        height = myimgmap.areas[i].style.height;
+        html +=
+          '<a style="position: absolute; top: ' +
+          top +
+          "; left: " +
+          left +
+          "; width: " +
+          width +
+          "; height: " +
+          height +
+          ';" ' +
+          ' alt="' +
+          myimgmap.areas[i].aalt +
+          '"' +
+          ' title="' +
+          myimgmap.areas[i].aalt +
+          '"' +
+          ' href="' +
+          myimgmap.areas[i].ahref +
+          '"' +
+          ' target="' +
+          myimgmap.areas[i].atarget +
+          '" ><em>' +
+          myimgmap.areas[i].atitle +
+          "</em></a>";
+      }
+    }
+  }
+  html += myimgmap.waterMark + "</div>";
+  //alert(html);
+  return html;
 }
 
 /**
@@ -678,24 +856,32 @@ desc bottom-left
  
  */
 function output_wiki() {
-	var html, coords;
-	html = '<imagemap>';
-	if (typeof myimgmap.pic != 'undefined') {
-		html+= 'Image:' + myimgmap.pic.src + '|' + myimgmap.pic.title + '\n';
-	}
-	
-	//foreach areas
-	for (var i=0; i<myimgmap.areas.length; i++) {
-		if (myimgmap.areas[i]) {
-			if (myimgmap.areas[i].shape && myimgmap.areas[i].shape != 'undefined') {
-				coords = myimgmap.areas[i].lastInput.split(',').join(' ');
-				html+= myimgmap.areas[i].shape + ' ' + coords + ' [[' + myimgmap.areas[i].ahref + '|' + myimgmap.areas[i].aalt + ']]\n';
-			}
-		}
-	}
-	html+= '#' + myimgmap.waterMark + '\n</imagemap>';
-	//alert(html);
-	return html;
+  var html, coords;
+  html = "<imagemap>";
+  if (typeof myimgmap.pic != "undefined") {
+    html += "Image:" + myimgmap.pic.src + "|" + myimgmap.pic.title + "\n";
+  }
+
+  //foreach areas
+  for (var i = 0; i < myimgmap.areas.length; i++) {
+    if (myimgmap.areas[i]) {
+      if (myimgmap.areas[i].shape && myimgmap.areas[i].shape != "undefined") {
+        coords = myimgmap.areas[i].lastInput.split(",").join(" ");
+        html +=
+          myimgmap.areas[i].shape +
+          " " +
+          coords +
+          " [[" +
+          myimgmap.areas[i].ahref +
+          "|" +
+          myimgmap.areas[i].aalt +
+          "]]\n";
+      }
+    }
+  }
+  html += "#" + myimgmap.waterMark + "\n</imagemap>";
+  //alert(html);
+  return html;
 }
 
 /** BROWSERPLUS SECTION *******************************************************/


### PR DESCRIPTION
The purpose of this pool request is to make the imgmap tool export compatible with the format of the spip plugin [Image Cliquable](https://contrib.spip.net/Plugin-Image-Cliquable).

New Features:
Export to SPIP format: Added functionality to export image maps to SPIP format.
Maphilight visibility toggle: Added a button to change the visibility of maphilight (only for spip export).
List visibility toggle: Added a button to change the visibility of list of links (only for spip export).